### PR TITLE
run K6 endpoint load tests

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,11 +1,11 @@
 const product = require('./product');
 const styles = require('./styles');
 const related = require('./related');
-const reviewsMeta = require('./reviewsMeta');
+// const reviewsMeta = require('./reviewsMeta');
 
 module.exports = {
   products: product,
   styles,
   related,
-  reviewsMeta,
+  // reviewsMeta,
 };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,14 +3,14 @@ const controllers = require('../controllers');
 const products = require('./products');
 const styles = require('./styles');
 const related = require('./related');
-const reviewsMeta = require('./reviewsMeta');
+// const reviewsMeta = require('./reviewsMeta');
 
 const router = Router();
 
 router.use('/products', products);
 router.use('/products', styles);
 router.use('/products', related);
-router.use('/reviews/meta', reviewsMeta);
+// router.use('/reviews/meta', reviewsMeta);
 
 router.get('/', (req, res) => res.send('This is root!'));
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"format": "prettier --write .",
 		"sequelize": "sequelize --options-path=config/options.js",
 		"csv:clean-file": "node csv_data/csvFileCleaner.js",
-		"csv:clean-all": "for i in csv_data/*.csv; do fullfilename=$i; filename=$(basename \"$fullfilename\"); fname=\"${filename%.*}\"; TARGET_FILE=\"$fname\" npm run csv:clean-file; done"
+		"csv:clean-all": "for i in csv_data/*.csv; do fullfilename=$i; filename=$(basename \"$fullfilename\"); fname=\"${filename%.*}\"; TARGET_FILE=\"$fname\" npm run csv:clean-file; done",
+		"k6:test": "sh resources/k6-tests/load-test.sh"
 	},
 	"repository": {
 		"type": "git",

--- a/resources/k6-test.js
+++ b/resources/k6-test.js
@@ -1,0 +1,13 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 10,
+  duration: '10s',
+};
+export default function () {
+  const res = http.get('localhost3000/products');
+  check(res, {
+    success: (r) => r.status === 200,
+  });
+}

--- a/resources/k6-tests/k6.js
+++ b/resources/k6-tests/k6.js
@@ -6,7 +6,8 @@ export const options = {
   duration: '10s',
 };
 export default function () {
-  const res = http.get('localhost3000/products');
+  // const endpoint = process.env.ENDPOINT;
+  const res = http.get(`http://localhost:3000/${__ENV.ENDPOINT}`);
   check(res, {
     success: (r) => r.status === 200,
   });

--- a/resources/k6-tests/load-test.sh
+++ b/resources/k6-tests/load-test.sh
@@ -1,0 +1,14 @@
+cd resources/k6-tests
+
+NOW=`date '+%F_%H:%M:%S'`
+mkdir "test_${NOW}"
+
+# Output to folders:
+ENDPOINT=products k6 run ./k6.js > "test_${NOW}/products.md"
+ENDPOINT=products/42370/styles k6 run ./k6.js > "test_${NOW}/styles.md"
+ENDPOINT=products/42370/related k6 run ./k6.js > "test_${NOW}/related.md"
+
+# Print to the console:
+# ENDPOINT=products k6 run ./k6.js
+# ENDPOINT=products/42370/styles k6 run ./k6.js
+# ENDPOINT=products/42370/related k6 run ./k6.js

--- a/resources/k6-tests/test_2021-10-01_19:26:52/products.md
+++ b/resources/k6-tests/test_2021-10-01_19:26:52/products.md
@@ -1,0 +1,77 @@
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ./k6.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 10 max VUs, 40s max duration (incl. graceful stop):
+           * default: 10 looping VUs for 10s (gracefulStop: 30s)
+
+
+running (01.0s), 10/10 VUs, 1014 complete and 0 interrupted iterations
+default   [  10% ] 10 VUs  01.0s/10s
+
+running (02.0s), 10/10 VUs, 2173 complete and 0 interrupted iterations
+default   [  20% ] 10 VUs  02.0s/10s
+
+running (02.7s), 10/10 VUs, 3040 complete and 0 interrupted iterations
+default   [  27% ] 10 VUs  02.7s/10s
+
+running (03.0s), 10/10 VUs, 3384 complete and 0 interrupted iterations
+default   [  30% ] 10 VUs  03.0s/10s
+
+running (03.0s), 10/10 VUs, 3428 complete and 0 interrupted iterations
+default   [  30% ] 10 VUs  03.0s/10s
+
+running (04.0s), 10/10 VUs, 4700 complete and 0 interrupted iterations
+default   [  40% ] 10 VUs  04.0s/10s
+
+running (05.0s), 10/10 VUs, 6449 complete and 0 interrupted iterations
+default   [  50% ] 10 VUs  05.0s/10s
+
+running (06.0s), 10/10 VUs, 8443 complete and 0 interrupted iterations
+default   [  60% ] 10 VUs  06.0s/10s
+
+running (07.0s), 10/10 VUs, 10564 complete and 0 interrupted iterations
+default   [  70% ] 10 VUs  07.0s/10s
+
+running (08.0s), 10/10 VUs, 12505 complete and 0 interrupted iterations
+default   [  80% ] 10 VUs  08.0s/10s
+
+running (08.9s), 10/10 VUs, 13730 complete and 0 interrupted iterations
+default   [  89% ] 10 VUs  08.9s/10s
+
+running (09.0s), 10/10 VUs, 13858 complete and 0 interrupted iterations
+default   [  90% ] 10 VUs  09.0s/10s
+
+running (10.0s), 10/10 VUs, 15931 complete and 0 interrupted iterations
+default   [ 100% ] 10 VUs  10.0s/10s
+
+running (10.0s), 00/10 VUs, 15945 complete and 0 interrupted iterations
+default ✓ [ 100% ] 10 VUs  10s
+
+     ✓ success
+
+     checks.........................: 100.00% ✓ 15945     ✗ 0    
+     data_received..................: 29 MB   2.9 MB/s
+     data_sent......................: 1.4 MB  140 kB/s
+     http_req_blocked...............: avg=1.74µs  min=0s     med=1µs    max=925µs    p(90)=2µs     p(95)=3µs    
+     http_req_connecting............: avg=254ns   min=0s     med=0s     max=474µs    p(90)=0s      p(95)=0s     
+     http_req_duration..............: avg=6.21ms  min=1.42ms med=4.06ms max=184.68ms p(90)=10.67ms p(95)=14.35ms
+       { expected_response:true }...: avg=6.21ms  min=1.42ms med=4.06ms max=184.68ms p(90)=10.67ms p(95)=14.35ms
+     http_req_failed................: 0.00%   ✓ 0         ✗ 15945
+     http_req_receiving.............: avg=28.66µs min=5µs    med=17µs   max=6.45ms   p(90)=55µs    p(95)=71µs   
+     http_req_sending...............: avg=6.79µs  min=1µs    med=3µs    max=7.06ms   p(90)=11µs    p(95)=15µs   
+     http_req_tls_handshaking.......: avg=0s      min=0s     med=0s     max=0s       p(90)=0s      p(95)=0s     
+     http_req_waiting...............: avg=6.17ms  min=1.41ms med=4.03ms max=184.62ms p(90)=10.6ms  p(95)=14.29ms
+     http_reqs......................: 15945   1594.1053/s
+     iteration_duration.............: avg=6.26ms  min=1.46ms med=4.11ms max=184.77ms p(90)=10.74ms p(95)=14.45ms
+     iterations.....................: 15945   1594.1053/s
+     vus............................: 10      min=10      max=10 
+     vus_max........................: 10      min=10      max=10 
+

--- a/resources/k6-tests/test_2021-10-01_19:26:52/related.md
+++ b/resources/k6-tests/test_2021-10-01_19:26:52/related.md
@@ -1,0 +1,80 @@
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ./k6.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 10 max VUs, 40s max duration (incl. graceful stop):
+           * default: 10 looping VUs for 10s (gracefulStop: 30s)
+
+
+running (00.3s), 10/10 VUs, 0 complete and 0 interrupted iterations
+default   [   3% ] 10 VUs  00.3s/10s
+
+running (00.6s), 10/10 VUs, 0 complete and 0 interrupted iterations
+default   [   6% ] 10 VUs  00.6s/10s
+
+running (01.0s), 10/10 VUs, 4 complete and 0 interrupted iterations
+default   [  10% ] 10 VUs  01.0s/10s
+
+running (02.0s), 10/10 VUs, 8 complete and 0 interrupted iterations
+default   [  20% ] 10 VUs  02.0s/10s
+
+running (03.0s), 10/10 VUs, 16 complete and 0 interrupted iterations
+default   [  30% ] 10 VUs  03.0s/10s
+
+running (04.0s), 10/10 VUs, 20 complete and 0 interrupted iterations
+default   [  40% ] 10 VUs  04.0s/10s
+
+running (05.0s), 10/10 VUs, 27 complete and 0 interrupted iterations
+default   [  50% ] 10 VUs  05.0s/10s
+
+running (06.0s), 10/10 VUs, 34 complete and 0 interrupted iterations
+default   [  60% ] 10 VUs  06.0s/10s
+
+running (07.0s), 10/10 VUs, 41 complete and 0 interrupted iterations
+default   [  70% ] 10 VUs  07.0s/10s
+
+running (07.8s), 10/10 VUs, 46 complete and 0 interrupted iterations
+default   [  78% ] 10 VUs  07.8s/10s
+
+running (08.0s), 10/10 VUs, 49 complete and 0 interrupted iterations
+default   [  80% ] 10 VUs  08.0s/10s
+
+running (09.0s), 10/10 VUs, 55 complete and 0 interrupted iterations
+default   [  90% ] 10 VUs  09.0s/10s
+
+running (10.0s), 10/10 VUs, 60 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (11.0s), 01/10 VUs, 69 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (11.1s), 00/10 VUs, 70 complete and 0 interrupted iterations
+default ✓ [ 100% ] 10 VUs  10s
+
+     ✓ success
+
+     checks.........................: 100.00% ✓ 70       ✗ 0   
+     data_received..................: 18 kB   1.6 kB/s
+     data_sent......................: 7.1 kB  646 B/s
+     http_req_blocked...............: avg=152.82µs min=1µs      med=4µs   max=1.15ms p(90)=1.03ms  p(95)=1.04ms  
+     http_req_connecting............: avg=58.87µs  min=0s       med=0s    max=476µs  p(90)=391.4µs p(95)=410.15µs
+     http_req_duration..............: avg=1.48s    min=918.61ms med=1.38s max=3.36s  p(90)=1.95s   p(95)=2.09s   
+       { expected_response:true }...: avg=1.48s    min=918.61ms med=1.38s max=3.36s  p(90)=1.95s   p(95)=2.09s   
+     http_req_failed................: 0.00%   ✓ 0        ✗ 70  
+     http_req_receiving.............: avg=79.62µs  min=33µs     med=73µs  max=140µs  p(90)=104.3µs p(95)=116.55µs
+     http_req_sending...............: avg=22.65µs  min=9µs      med=17µs  max=110µs  p(90)=36µs    p(95)=54.19µs 
+     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s    max=0s     p(90)=0s      p(95)=0s      
+     http_req_waiting...............: avg=1.48s    min=918.46ms med=1.38s max=3.36s  p(90)=1.95s   p(95)=2.09s   
+     http_reqs......................: 70      6.330433/s
+     iteration_duration.............: avg=1.48s    min=920.01ms med=1.38s max=3.36s  p(90)=1.95s   p(95)=2.09s   
+     iterations.....................: 70      6.330433/s
+     vus............................: 1       min=1      max=10
+     vus_max........................: 10      min=10     max=10
+

--- a/resources/k6-tests/test_2021-10-01_19:26:52/styles.md
+++ b/resources/k6-tests/test_2021-10-01_19:26:52/styles.md
@@ -1,0 +1,92 @@
+
+          /\      |‾‾| /‾‾/   /‾‾/   
+     /\  /  \     |  |/  /   /  /    
+    /  \/    \    |     (   /   ‾‾\  
+   /          \   |  |\  \ |  (‾)  | 
+  / __________ \  |__| \__\ \_____/ .io
+
+  execution: local
+     script: ./k6.js
+     output: -
+
+  scenarios: (100.00%) 1 scenario, 10 max VUs, 40s max duration (incl. graceful stop):
+           * default: 10 looping VUs for 10s (gracefulStop: 30s)
+
+
+running (01.0s), 10/10 VUs, 0 complete and 0 interrupted iterations
+default   [  10% ] 10 VUs  01.0s/10s
+
+running (02.0s), 10/10 VUs, 0 complete and 0 interrupted iterations
+default   [  20% ] 10 VUs  02.0s/10s
+
+running (03.0s), 10/10 VUs, 0 complete and 0 interrupted iterations
+default   [  30% ] 10 VUs  03.0s/10s
+
+running (04.0s), 10/10 VUs, 0 complete and 0 interrupted iterations
+default   [  40% ] 10 VUs  04.0s/10s
+
+running (05.0s), 10/10 VUs, 3 complete and 0 interrupted iterations
+default   [  50% ] 10 VUs  05.0s/10s
+
+running (06.0s), 10/10 VUs, 5 complete and 0 interrupted iterations
+default   [  60% ] 10 VUs  06.0s/10s
+
+running (06.9s), 10/10 VUs, 5 complete and 0 interrupted iterations
+default   [  69% ] 10 VUs  06.9s/10s
+
+running (07.0s), 10/10 VUs, 5 complete and 0 interrupted iterations
+default   [  70% ] 10 VUs  07.0s/10s
+
+running (07.1s), 10/10 VUs, 5 complete and 0 interrupted iterations
+default   [  71% ] 10 VUs  07.1s/10s
+
+running (08.0s), 10/10 VUs, 7 complete and 0 interrupted iterations
+default   [  80% ] 10 VUs  08.0s/10s
+
+running (08.0s), 10/10 VUs, 7 complete and 0 interrupted iterations
+default   [  80% ] 10 VUs  08.0s/10s
+
+running (09.0s), 10/10 VUs, 7 complete and 0 interrupted iterations
+default   [  90% ] 10 VUs  09.0s/10s
+
+running (10.0s), 10/10 VUs, 9 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (11.0s), 09/10 VUs, 10 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (12.0s), 06/10 VUs, 13 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (13.0s), 05/10 VUs, 14 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (14.0s), 03/10 VUs, 16 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (15.0s), 01/10 VUs, 18 complete and 0 interrupted iterations
+default ↓ [ 100% ] 10 VUs  10s
+
+running (15.1s), 00/10 VUs, 19 complete and 0 interrupted iterations
+default ✓ [ 100% ] 10 VUs  10s
+
+     ✓ success
+
+     checks.........................: 100.00% ✓ 19       ✗ 0   
+     data_received..................: 9.0 kB  597 B/s
+     data_sent......................: 1.9 kB  127 B/s
+     http_req_blocked...............: avg=579.94µs min=1µs   med=935µs max=1.19ms p(90)=1.15ms  p(95)=1.18ms  
+     http_req_connecting............: avg=211.94µs min=0s    med=348µs max=451µs  p(90)=445.4µs p(95)=447.4µs 
+     http_req_duration..............: avg=6.76s    min=4.53s med=6.61s max=11.62s p(90)=9.74s   p(95)=10.52s  
+       { expected_response:true }...: avg=6.76s    min=4.53s med=6.61s max=11.62s p(90)=9.74s   p(95)=10.52s  
+     http_req_failed................: 0.00%   ✓ 0        ✗ 19  
+     http_req_receiving.............: avg=103.15µs min=38µs  med=73µs  max=450µs  p(90)=131.4µs p(95)=211.49µs
+     http_req_sending...............: avg=23.05µs  min=11µs  med=17µs  max=68µs   p(90)=38µs    p(95)=59µs    
+     http_req_tls_handshaking.......: avg=0s       min=0s    med=0s    max=0s     p(90)=0s      p(95)=0s      
+     http_req_waiting...............: avg=6.76s    min=4.53s med=6.61s max=11.62s p(90)=9.74s   p(95)=10.52s  
+     http_reqs......................: 19      1.254978/s
+     iteration_duration.............: avg=6.76s    min=4.53s med=6.62s max=11.62s p(90)=9.74s   p(95)=10.52s  
+     iterations.....................: 19      1.254978/s
+     vus............................: 1       min=1      max=10
+     vus_max........................: 10      min=10     max=10
+


### PR DESCRIPTION
Set up the [k6](https://k6.io/) for stress testing. Read this [article](https://medium.com/codeinsights/how-to-load-test-your-node-js-app-using-k6-74d7339bc787).

Created an npm script to generate a (time-stamped) folder with endpoint tests. `npm run k6:load`. All endpoints return 100% checks. See `resources/k6-tests/test_NNNN/*` for results in markdown files.

Ran a load test with k6 for these three endpoints:
```sh
# Output to folders:
ENDPOINT=products k6 run ./k6.js > "test_${NOW}/products.md"
ENDPOINT=products/42370/styles k6 run ./k6.js > "test_${NOW}/styles.md"
ENDPOINT=products/42370/related k6 run ./k6.js > "test_${NOW}/related.md"

```
